### PR TITLE
issue #28308 - Fix Qt5 Windows crash by backporting change from main trojita code

### DIFF
--- a/src/Imap/Model/Model.cpp
+++ b/src/Imap/Model/Model.cpp
@@ -766,7 +766,19 @@ void Model::askForChildrenOfMailbox(TreeItemMailbox *item, bool forceReload)
         QList<MailboxMetadata> metadata = cache()->childMailboxes(item->mailbox());
         QList<TreeItem *> mailboxes;
         for (QList<MailboxMetadata>::const_iterator it = metadata.constBegin(); it != metadata.constEnd(); ++it) {
-            mailboxes << TreeItemMailbox::fromMetadata(item, *it);
+            TreeItemMailbox *mailbox = TreeItemMailbox::fromMetadata(item, *it);
+            TreeItemMsgList *list = dynamic_cast<TreeItemMsgList*>(mailbox->m_children[0]);
+            Q_ASSERT(list);
+            Imap::Mailbox::SyncState syncState = cache()->mailboxSyncState(mailbox->mailbox());
+            if (syncState.isUsableForNumbers()) {
+                list->m_unreadMessageCount = syncState.unSeenCount();
+                list->m_totalMessageCount = syncState.exists();
+                list->m_recentMessageCount = syncState.recent();
+                list->m_numberFetchingStatus = TreeItem::DONE;
+            } else {
+                list->m_numberFetchingStatus = TreeItem::UNAVAILABLE;
+            }
+            mailboxes << mailbox;
         }
         TreeItemMailbox *mailboxPtr = dynamic_cast<TreeItemMailbox *>(item);
         Q_ASSERT(mailboxPtr);


### PR DESCRIPTION
There is a bug in trojita itself that appears to have never been caught and was fixed accidentally on the main jktjkt branch. If trojita is built with Qt 5.5.1 (possibly other Qt5 versions as well) for Windows, it will crash immediately upon trying to run it. The cause is a segmentation fault in the KDescendantsProxyModel. When processPendingParents is called to populate the model, it emits rowsInserted in the process (as a part of calling endRowsInserted), which is picked up by the TaskProgressIndicator. When processPendingParents is two levels deep, then the model has children, and setVisible(true) is called for the TaskProgressIndicator. For some reason, only on Windows and certain versions of Qt, the process of redrawing the parent layout queries the QtDisplayRole for the PrettyMailboxModel. Because the display wants to show how many unread messages there are, it gets the MailboxTree to ask for the number of messages. This results in the creation of a NumberOfMessagesTask, which changes the contents of the TaskPresentationModel and triggers a reset on the model. This caused the KDescendentsProxyModel to reset its contents and start over with processPendingParents. When it finishes populating and setVisible(true) finishes, control returns to the previous iteration of processPendingParents lower on the stack, however, it continues from that point with the model already populated when it shouldn't be. This disrupts updateInternalIndexes and insertion into the mapping causing it to insert an item that already exists at a different index, which results in the existing index changing. Then when it tries to find it at the old index in mapToSource with rightLowerBound, it can't, and grabs the end of the list. When it attempts to dereference the end of list pointer, a segmentation fault is thrown.

This change, intended to fix something unrelated, is the change that eliminates the bug on the main branch. It changes the m_numberFetchingStatus for the MailboxTree away from NONE before processPendingParents is called, which means when it tries to grab the number of unread messages, it doesn't create a new task anymore, preventing the corruption of the proxy model.